### PR TITLE
Add Support for Android using Latest RN Modules

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -94,13 +94,13 @@ def enableSeparateBuildPerCPUArchitecture = false
 def enableProguardInReleaseBuilds = false
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.walletconnectapp"
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         ndk {
@@ -137,7 +137,10 @@ android {
 }
 
 dependencies {
-    compile project(':react-native-camera')
+    // compile project(':react-native-camera')
+    compile (project(':react-native-camera')) {
+       exclude group: "com.android.support", module: 'support-v4'
+    }
     compile project(':react-native-udp')
     compile project(':react-native-tcp')
     compile project(':react-native-randombytes')

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.walletconnectapp">
 
+    <uses-permission android:name="android.permission.VIBRATE"/> <!-- QRScanner Permission -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,10 +3,15 @@
 buildscript {
     repositories {
         jcenter()
+        google()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
-
+        classpath 'com.android.tools.build:gradle:3.1.0'
+        
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -16,9 +21,36 @@ allprojects {
     repositories {
         mavenLocal()
         jcenter()
+        google()
+        maven { 
+            url "https://jitpack.io" 
+        }
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
         }
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
+}
+
+subprojects {
+ project.configurations.all {
+    resolutionStrategy.eachDependency { details ->
+       if (details.requested.group == 'com.android.support'
+             && !details.requested.name.contains('multidex') ) {
+          details.useVersion "26.1.0"
+       }
+    }
+ }
+}
+
+ext {
+    buildToolsVersion = "26.0.3"
+    minSdkVersion = 16
+    compileSdkVersion = 26
+    targetSdkVersion = 26
+    supportLibVersion = "26.1.0"
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip # Update for Latest Camera/QRScanner modules


### PR DESCRIPTION
To use the latest react-native-camera and react-native-qr-scanner modules requires updating to Gradle 3.0 and changing a few other minor compile changes.

I've setup the changes on a different project and succesfully compiled the React Native application.

Now I get React specific errors regarding children not being in an array. However, when inspecting the code everything appears to be in order.

![](https://imgur.com/ltHy7zy.png)